### PR TITLE
The function to update FAERS downloads only ascii databases

### DIFF
--- a/R/check_faers_structure.R
+++ b/R/check_faers_structure.R
@@ -80,7 +80,7 @@ check_quarter_every_year <- function(path, faers_years) {
     faers_years,
     function(x) check_quarter_directory(path = path, year = x)
   )
-  sum(!purrr::map(subfolders_logical, sum) > 0) == 0
+  sum(!purrr::map(subfolders_logical, sum) > 0L) == 0L
 }
 
 
@@ -113,7 +113,7 @@ check_files <- function(path, current_filenames = all_possible_filenames()) {
                        "{toString(filelist[which(!files_logical)])}. ",
                        "Please remove the files or change directory path."))
   }
-  length(filelist[which(!files_logical)]) == 0
+  length(filelist[which(!files_logical)]) == 0L
 }
 
 

--- a/R/update_local.R
+++ b/R/update_local.R
@@ -1,6 +1,6 @@
-#' Update local FAERS data
+#' Update local FAERS data (ascii files only)
 #'
-#' This function downloads the FAERS data missing in the selected folder.
+#' This function downloads the FAERS ascii data missing in the selected folder.
 #'
 #' @param path (chr) The path of the folder containing a subfolder (named
 #' "faers_raw_data") with FAERS data inside, sorted by year and quarter.
@@ -22,10 +22,19 @@ update_local <- function(path,
                          missing_metadata = what_is_missing(path),
                          permission_to_update = NULL) {
   if (!check_faers_structure(path)) return(invisible(FALSE))
+  missing_metadata <- missing_metadata %>%
+    dplyr::filter(.data[["type"]] == "ascii")
   if (NROW(missing_metadata) == 0L) {
-    message("No new data to download.")
+    message("No new ascii data to download.")
     return(invisible(FALSE))
   }
+  nmiss <- NROW(missing_metadata)
+  mbmiss <- sum(missing_metadata[["mb"]])
+  message(
+    glue::glue(
+      "{nmiss} FAERS ascii databases are missing in your folder ({mbmiss} mb)."
+    )
+  )
   if (permission_update(permission_to_update, path)) {
     mapply(
       function(x, y) retrieve_qde(path, year = x, quarter = y, type = "ascii",

--- a/R/update_local.R
+++ b/R/update_local.R
@@ -28,11 +28,10 @@ update_local <- function(path,
   }
   if (permission_update(permission_to_update, path)) {
     mapply(
-      function(x, y, z) retrieve_qde(path, year = x, quarter = y, type = z,
-                                     interactive_session = FALSE),
+      function(x, y) retrieve_qde(path, year = x, quarter = y, type = "ascii",
+                                  interactive_session = FALSE),
       missing_metadata[["year"]],
-      missing_metadata[["quarter"]],
-      missing_metadata[["type"]]
+      missing_metadata[["quarter"]]
     )
     return(invisible(TRUE))
   } else {

--- a/R/what_is_missing.R
+++ b/R/what_is_missing.R
@@ -24,7 +24,7 @@ what_is_missing <- function(path, faers_meta = fetch_faers_meta()) {
     dplyr::filter(!(.data[["unq"]] %in% local[["unq"]])) %>%
     dplyr::select(-.data[["unq"]]) %>%
     dplyr::mutate(dplyr::across(dplyr::everything(),
-                                ~tidyr::replace_na(.x, 0))) %>%
+                                ~tidyr::replace_na(.x, 0L))) %>%
     dplyr::transmute(.data[["year"]], .data[["quarter"]], .data[["type"]],
                      mb = .data[["ascii_zip_mb"]] + .data[["xml_zip_mb"]])
   totmb <- sum(out[["mb"]])

--- a/R/what_is_missing.R
+++ b/R/what_is_missing.R
@@ -28,8 +28,6 @@ what_is_missing <- function(path, faers_meta = fetch_faers_meta()) {
     dplyr::transmute(.data[["year"]], .data[["quarter"]], .data[["type"]],
                      mb = .data[["ascii_zip_mb"]] + .data[["xml_zip_mb"]])
   totmb <- sum(out[["mb"]])
-  message(glue::glue("{NROW(out)} FAERS databases are missing in your folder",
-                     " ({totmb} mb)."))
   out
 }
 

--- a/man/update_local.Rd
+++ b/man/update_local.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/update_local.R
 \name{update_local}
 \alias{update_local}
-\title{Update local FAERS data}
+\title{Update local FAERS data (ascii files only)}
 \usage{
 update_local(
   path,
@@ -26,7 +26,7 @@ TRUE: permission to download files, FALSE: deny permission to download files.}
 (lgl) TRUE if the download was successful, FALSE otherwise.
 }
 \description{
-This function downloads the FAERS data missing in the selected folder.
+This function downloads the FAERS ascii data missing in the selected folder.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Since XML data download is causing problems, and the data content of XML and ascii files is the same, we bypass issue #18 and allow the update_local function to download only ascii data.